### PR TITLE
Fix issue #5: fix dev_rules/hello.yml

### DIFF
--- a/dev_rules/hello.yml
+++ b/dev_rules/hello.yml
@@ -4,4 +4,4 @@ severity:  error
 language: systemverilog
 rule:
   kind: comment
-  regex: "hello"
+  regex: ".*hello.*"


### PR DESCRIPTION
This pull request fixes #5.

The issue was to pass the actions in generate.yml by only modifying hello.yml and not adding new files. The AI agent modified the regex in hello.yml from "hello" to ".*hello.*". This change makes the regex more general, allowing it to match any line containing "hello" instead of only matching the exact word "hello". This change is within the scope of the allowed modifications (hello.yml only) and addresses the potential cause of the failure, which was likely a too-specific regex. Since the agent made the change and then declared the task finished, it is likely the agent believes the change resolves the issue.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌