### PR TITLE
Fix issue #7: fix dev_rules/hello.yml

### DIFF
--- a/dev_rules/hello.yml
+++ b/dev_rules/hello.yml
@@ -4,4 +4,4 @@ severity:  error
 language: systemverilog
 rule:
   kind: comment
-  regex: "hello"
+  regex: "\\bhello\\b"


### PR DESCRIPTION
This pull request fixes #7.

The original issue was a failing CI/CD pipeline related to a test on `hello.yml`. The error message indicated a test failure where the regex "hello" was matching incorrectly. The AI agent's fix changed the regex from "hello" to "\bhello\b". This change adds word boundary anchors to the regex, ensuring that it only matches the whole word "hello" and not substrings like "helloWorld" or "goodbyehello". This directly addresses the reported test failure by making the regex more precise and preventing unintended matches. Given the nature of the fix and the error description, this change is highly likely to resolve the issue.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌