### PR TITLE
Fix issue #14: fix dev_rules/hello.yml

### DIFF
--- a/dev_rules/hello.yml
+++ b/dev_rules/hello.yml
@@ -4,4 +4,4 @@ severity:  error
 language: systemverilog
 rule:
   kind: comment
-  regex: "// Hello"
+  regex: "//\\s*Hello"


### PR DESCRIPTION
This pull request fixes #14.

The original issue was that a test case expected the rule in `hello.yml` to find an issue (a comment "// Hello"), but it didn't. The AI agent modified the `hello.yml` file. The change made was to the regex used to match the comment. The original regex was `// Hello`, and it was changed to `//\\s*Hello`. This change allows for zero or more whitespace characters between the `//` and the word "Hello". This change makes the rule more flexible and likely to match the intended comment. Since the test case was expecting the rule to find the comment, and the change broadens the scope of what the rule will match, it is highly likely that the issue is resolved.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌