### PR TITLE
Fix issue #27: lowRISC_rules/signal_widths.ymlを修正する。

### DIFF
--- a/lowRISC_rules/signal_widths.yml
+++ b/lowRISC_rules/signal_widths.yml
@@ -79,13 +79,25 @@ rule:
   kind: integral_number
   not:
     any:
-      - has:
-          field: size
-          kind: unsigned_number
+      - has: # Checks for explicit size, e.g., '4' in 4'd4
+          all:
+            - kind: decimal_number
+            - has:
+                field: size
+                kind: unsigned_number
+                stopBy: end
           stopBy: end
-      - has:
-          field: base
-          kind: decimal_base
+      - has: # Checks for explicit base, e.g., 'd' in 4'd4
+          all:
+            - kind: decimal_number
+            - has:
+                field: base
+                any:
+                  - kind: decimal_base
+                  - kind: hex_base
+                  - kind: binary_base
+                  - kind: octal_base
+                stopBy: end
           stopBy: end
       - inside:
           kind: packed_dimension


### PR DESCRIPTION
This pull request fixes #27.

The issue required modifying `lowRISC_rules/signal_widths.yml` to correctly identify integral numbers with explicit widths or bases, ensuring the ast-grep tests pass. The agent identified two key problems:
1.  The original rule incorrectly assumed `size` and `base` were direct fields of `integral_number` nodes, whereas they are fields of an intermediate `decimal_number` node within the `integral_number`.
2.  The rule only considered `decimal_base` and failed to account for `hex_base`, `binary_base`, and `octal_base`.

The provided patch directly addresses these issues:
1.  **Corrected AST traversal:** The `has` conditions for `size` and `base` were wrapped in an `all` block that first asserts the `kind` is `decimal_number`, and then checks for the `has: field: size` or `has: field: base` within that `decimal_number`. This accurately reflects the SystemVerilog CST structure for numeric literals, allowing the rule to correctly identify explicitly sized numbers like `4'd4`.
2.  **Expanded base kind recognition:** The `base` field check was updated to include `hex_base`, `binary_base`, and `octal_base` alongside `decimal_base` using an `any` block. This ensures that numbers with explicit bases in different radixes (e.g., `8'hFF`, `1'b1`) are also correctly excluded from being flagged by the rule.

By making these changes, the rule's `not` conditions (which define what *not* to flag) are now accurate, leading to the expected behavior of passing the ast-grep tests as claimed by the agent.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌