### PR TITLE
Fix issue #30: svuff/lowRISC_rules /Sequential_Logic_Registers.yml を修正する。

### DIFF
--- a/lowRISC_rules/Sequential_Logic_Registers.yml
+++ b/lowRISC_rules/Sequential_Logic_Registers.yml
@@ -4,11 +4,16 @@ message: In a sequential always block, only use non-blocking assignments (<=). N
 severity:  error
 language: systemverilog
 rule:
-     kind: procedural_timing_control_statement
-     not:
+     kind: blocking_assignment
+     inside:
+       kind: always_construct
        has:
-        kind: seq_block
-        stopBy: end
+         kind: always_keyword
+         has:
+           pattern: always_ff
+           stopBy: end
+         stopBy: end
+       stopBy: end
 note: |
   Designs that mix blocking and non-blocking assignments for registers simulate incorrectly because some simulators process some of the blocking assignments in an always block as occurring in a separate simulation event as the non-blocking assignment. 
   This process makes some signals jump registers, potentially leading to total protonic reversal. That's bad.


### PR DESCRIPTION
This pull request fixes #30.

The issue aimed to modify `lowRISC_rules/Sequential_Logic_Registers.yml` to detect blocking assignments (`=`) within `always_ff` blocks and ensure the `ast-grep` tests pass.

The changes made to `lowRISC_rules/Sequential_Logic_Registers.yml` specifically target this requirement:
1.  **`kind: blocking_assignment`**: This correctly identifies the `=` operator used for blocking assignments.
2.  **`inside: kind: always_construct`**: This ensures that the detected blocking assignment is located within an `always` block.
3.  **`has: kind: always_keyword has: pattern: always_ff`**: This further refines the rule to specifically look for `always` constructs that are declared as `always_ff`.

By combining these conditions, the new rule precisely flags only `blocking_assignment` instances that occur inside `always_ff` blocks. The AI agent's final message confirms that "All `ast-grep` tests, including the one for `lowRISC_Sequential_Logic_Registers`, have passed," which indicates that the modified rule successfully identifies the `invalid` test cases without creating `noisy` matches for `valid` cases, directly fulfilling the "pass ast-grep tests" requirement. The changes to `.openhands/pre-commit.sh` and `.openhands/setup.sh` are minor permission changes to allow execution of scripts, not directly related to the rule logic but necessary for the testing process.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌