### PR TITLE
Fix issue #32: verible_rules /always_comb.yml を修正する。

### DIFF
--- a/verible_rules/always_comb.yml
+++ b/verible_rules/always_comb.yml
@@ -14,7 +14,13 @@ severity:  error
 language: systemverilog
 
 rule:
-  kind: integral_number
+  kind: always_construct
+  has:
+    kind: procedural_timing_control_statement
+    stopBy: end
+    has:
+      pattern: '@*'
+      stopBy: end
 
 
 


### PR DESCRIPTION
This pull request fixes #32.

The issue aimed to modify `verible_rules/always_comb.yml` to detect instances where `always` is used instead of `always_comb`. The provided solution changes the rule from an incorrect `kind: integral_number` to one that specifically targets `always_construct` nodes.

The new rule `kind: always_construct` combined with a nested `has` clause looking for `kind: procedural_timing_control_statement` containing the `pattern: '@*'` effectively detects `always @*` blocks. This change directly addresses the core problem, as `always @*` is the most common legacy `always` construct that `always_comb` is intended to replace for combinational logic.

The rule successfully distinguishes `always @*` from `always_comb`, `always_ff`, and `always_latch` because those do not contain the `@*` pattern in their sensitivity lists, thereby avoiding noisy matches on preferred constructs. The agent's confirmation that "All tests are passing" further supports that this specific and relevant subset of `always` blocks is correctly identified.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌