### PR TITLE
Create always_comb_blocking

### DIFF
--- a/verible_rules/always_comb_blocking
+++ b/verible_rules/always_comb_blocking
@@ -1,0 +1,24 @@
+# Portions Copyright 2023 CHIPS Alliance
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Additional modifications Copyright 2025 zoomer-k
+# Licensed under the MIT License
+
+id: verible_always-comb-blocking
+message: Checks that there are no occurrences of non-blocking assignment in combinational logic.
+severity:  error
+language: systemverilog
+
+rule:
+  kind: always_construct
+
+
+
+
+
+
+# note: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a rule to enforce the use of blocking assignments only within combinational logic blocks, treating violations as errors in SystemVerilog code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->