### PR TITLE
Fix issue #35: verible_rules /always_comb_blocking.yml　の修正

### DIFF
--- a/verible_rules/always_comb_blocking.yml
+++ b/verible_rules/always_comb_blocking.yml
@@ -21,7 +21,6 @@ rule:
         has:
           kind: always_keyword
           regex: ^always_comb$
-          stopBy: end
         stopBy: end
 
 

--- a/verible_rules/always_comb_blocking.yml
+++ b/verible_rules/always_comb_blocking.yml
@@ -14,7 +14,15 @@ severity:  error
 language: systemverilog
 
 rule:
-  kind: nonblocking_assignment
+  all:
+    - kind: nonblocking_assignment
+    - inside:
+        kind: always_construct
+        has:
+          kind: always_keyword
+          regex: ^always_comb$
+          stopBy: end
+        stopBy: end
 
 
 


### PR DESCRIPTION
This pull request fixes #35.

The issue aimed to modify `verible_rules/always_comb_blocking.yml` so that it detects non-blocking assignments (`<=`) *only* when they occur within an `always_comb` block, while ignoring them in `always_ff` blocks.

The original rule `kind: nonblocking_assignment` would detect all non-blocking assignments universally. The agent's change introduced an `all` combined rule with two conditions:
1.  `kind: nonblocking_assignment`: This specifies that the rule should target non-blocking assignment nodes.
2.  `inside:`: This nested condition ensures that the matched `nonblocking_assignment` must be located within an `always_construct` node.
    *   `has: kind: always_keyword, regex: ^always_comb$`: This further refines the `inside` condition, requiring that the enclosing `always_construct` must specifically contain an `always_keyword` whose text content is exactly "always_comb".

By combining `nonblocking_assignment` with the `inside` and `has` conditions filtering for `always_comb`, the rule now precisely targets the intended scenario. This correctly limits the detection of non-blocking assignments to `always_comb` blocks, effectively resolving the issue. The changes to `.openhands/pre-commit.sh` and `.openhands/setup.sh` are likely related to execution permissions for the testing environment and do not directly impact the rule logic itself.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated rule configuration to more accurately flag non-blocking assignments only within always_comb blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->