### PR TITLE
Fix issue #38: verible_rules /always_ff_non_blocking.yml を修正する。

### DIFF
--- a/verible_rules/always_ff_non_blocking.yml
+++ b/verible_rules/always_ff_non_blocking.yml
@@ -15,6 +15,13 @@ language: systemverilog
 
 rule:
   kind: blocking_assignment
+  inside:
+    kind: always_construct
+    stopBy: end
+    has:
+      kind: always_keyword
+      regex: "always_ff"
+      stopBy: end
 
 
 


### PR DESCRIPTION
This pull request fixes #38.

The issue required modifying `verible_rules/always_ff_non_blocking.yml` to detect blocking assignments (`=`) specifically when they are used inside `always_ff` blocks.

The `git patch` shows that the `verible_rules/always_ff_non_blocking.yml` file was modified.
Before the change, the rule was simply `kind: blocking_assignment`, which would detect any blocking assignment regardless of context.
After the change, an `inside` block was added to the rule:
```yaml
  inside:
    kind: always_construct
    stopBy: end
    has:
      kind: always_keyword
      regex: "always_ff"
      stopBy: end
```
This new structure ensures that a `blocking_assignment` is only matched if it is found *inside* an `always_construct` which, in turn, *contains* the `always_keyword` "always_ff". This precisely targets the condition described in the issue: "blocking assignment (`=`) used within `always_ff`".

The AI agent's last message states that "All 7 tests passed, including `verible_always-ff-non-blocking`" and that "the rule modification was successful." This indicates that the new rule correctly identifies the problematic code while not flagging valid code, thereby resolving the stated issue.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated rule to detect blocking assignments only within always_ff constructs, improving accuracy and reducing false positives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->