### PR TITLE
Fix issue #45: verible_rules/constraint_name_style.yml　を修正する。

### DIFF
--- a/verible_rules/constraint_name_style.yml
+++ b/verible_rules/constraint_name_style.yml
@@ -5,9 +5,8 @@ severity: error
 language: systemverilog
 rule:
   kind: constraint_declaration
-  has:
-    field: name
-    all:
-      - kind: simple_identifier
-      - not:
-          regex: "^([a-z0-9]+_)+c$"
+  all:
+    - pattern: "constraint $NAME { $$$BODY }"
+    - not:
+        pattern: "$NAME"
+        regex: "^([a-z0-9]+_)+c$"


### PR DESCRIPTION
This pull request fixes #45.

The AI agent successfully modified the `verible_rules/constraint_name_style.yml` file to accurately detect constraint names that do not conform to the specified naming convention.

The key change is the transition from using `has: field: name` to a `pattern` with a metavariable (`$NAME`).
1.  **Old rule:** It attempted to target the constraint's name using `has: field: name`. While the intent was correct, relying solely on `field` can sometimes be ambiguous or parser-dependent regarding how the 'name' field is exposed for a `constraint_declaration` node in the SystemVerilog CST.
2.  **New rule:** It now uses `pattern: "constraint $NAME { $$$BODY }"` to explicitly capture the identifier following the `constraint` keyword into the `$NAME` metavariable. This is a more robust and idiomatic way in ast-grep to extract the specific part of the syntax (the constraint name) that needs to be checked.
3.  **Core logic preserved:** The `not: regex: "^([a-z0-9]+_)+c$"` condition is correctly applied to the captured `$NAME` (via `not: pattern: "$NAME"`) to ensure that the rule flags constraint names that *do not* match the required pattern.

This change directly addresses the purpose of detecting naming violations by providing a more precise and reliable mechanism for identifying the constraint's name within the AST. The additional changes to `pre-commit.sh` and `setup.sh` simply make these scripts executable, which is necessary for the testing infrastructure but not directly related to the rule's logic itself. The fix to the rule file is a direct and effective improvement.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌