### PR TITLE
Fix issue #50: verible_rules/enum_name_style.ymlの修正する。

### DIFF
--- a/verible_rules/enum_name_style.yml
+++ b/verible_rules/enum_name_style.yml
@@ -14,13 +14,20 @@ severity:  error
 language: systemverilog
 
 rule:
-  kind: type_declaration
-  not:
-    has:
-      field: type_name
-      kind: simple_identifier
-      regex: '^[a-z_0-9]+(_t|_e)$'
-      stopBy: end
+  all:
+    - kind: type_declaration
+    - has:
+        inside:
+          kind: data_type
+          regex: '\benum\b'
+          stopBy: end
+        stopBy: end
+    - not:
+        has:
+          field: type_name
+          kind: simple_identifier
+          regex: '^[a-z_0-9]+(_t|_e)$'
+          stopBy: end
 
 note: |
       The default regex pattern expects “lower_snake_case” with either a “_t” or “_e” suffix. 


### PR DESCRIPTION
This pull request fixes #50.

The issue was that the `enum_name_style.yml` rule was incorrectly flagging all `type_declaration` nodes (e.g., `struct`, `union`) instead of only `enum` declarations. The AI agent resolved this by modifying the rule to include an additional condition that specifically checks for the presence of the "enum" keyword within the `data_type` node nested inside a `type_declaration`.

Specifically, the `rule` section was changed from:
```yaml
rule:
  kind: type_declaration
  not:
    has:
      field: type_name
      kind: simple_identifier
      regex: '^[a-z_0-9]+(_t|_e)$'
      stopBy: end
```
to:
```yaml
rule:
  all:
    - kind: type_declaration
    - has:
        inside:
          kind: data_type
          regex: '\benum\b'
          stopBy: end
        stopBy: end
    - not:
        has:
          field: type_name
          kind: simple_identifier
          regex: '^[a-z_0-9]+(_t|_e)$'
          stopBy: end
```
The key addition is the `has: inside: kind: data_type regex: '\benum\b'` clause, which ensures that for a `type_declaration` to be matched, it must also contain a `data_type` node that includes the literal word "enum". This effectively scopes the rule to only apply to `enum` declarations, as intended by the issue description's purpose. The change directly addresses the problem of over-matching and correctly targets `enum` types for style checking.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the enum naming style rule to target only enum type declarations, reducing false positives on non-enum types.
  * Continues to flag enum type names that match lower_snake_case with _t or _e suffixes.

* **Documentation**
  * Expanded guidance with references on enum naming and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->