### PR TITLE
Fix issue #53: update .openhands /setup.sh

### DIFF
--- a/.openhands/setup.sh
+++ b/.openhands/setup.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 sudo npm install --global tree-sitter-cli @ast-grep/cli
 tree-sitter init-config
-git clone --depth=1 https://github.com/gmlarumbe/tree-sitter-systemverilog /tmp/tree-sitter-systemverilog
+if [ ! -d "/tmp/tree-sitter-systemverilog" ]; then
+    git clone --depth=1 https://github.com/gmlarumbe/tree-sitter-systemverilog /tmp/tree-sitter-systemverilog
+fi
 pushd /tmp/tree-sitter-systemverilog
 tree-sitter generate -b --abi 14 --libdir .
-pushd
+popd
 sg test --skip-snapshot-tests
 
 


### PR DESCRIPTION
This pull request fixes #53.

The issue "use cache" has been resolved by modifying the `.openhands/setup.sh` script. Specifically, a conditional check `if [ ! -d "/tmp/tree-sitter-systemverilog" ]; then ... fi` was added around the `git clone` command for the `tree-sitter-systemverilog` repository. This change ensures that the repository is only cloned if it does not already exist in the `/tmp/tree-sitter-systemverilog` directory, effectively caching the cloned repository and preventing unnecessary re-cloning on subsequent runs of the setup script. Additionally, a typo was fixed by changing `pushd` to `popd`, ensuring the script correctly manages the directory stack, though this is not directly related to caching.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected directory navigation to ensure the setup script reliably returns to the original directory.

* **Chores**
  * Made dependency cloning idempotent by only cloning when the repository is absent, reducing redundant downloads and speeding up repeated setups.
  * Preserved existing install, config, generate, and test steps without behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->